### PR TITLE
Switched to protocol-buffers, consolidated duplicate code in loops

### DIFF
--- a/bin/shp2geobuf
+++ b/bin/shp2geobuf
@@ -4,5 +4,5 @@ var geobuf = require('../'),
     shapefile = require('shapefile');
 
 shapefile.read(process.argv[2], function(err, geojson) {
-    process.stdout.write(geobuf.featureCollectionToGeobuf(geojson).toBuffer());
+    process.stdout.write(geobuf.featureCollectionToGeobuf(geojson));
 });

--- a/geobuf.proto
+++ b/geobuf.proto
@@ -36,6 +36,16 @@ message id {
 }
 
 message value {
+    enum Type {
+        bool_value = 0;
+        string_value = 1;
+        float_value = 2;
+        double_value = 3;
+        int_value = 4;
+        uint_value = 5;
+        sint_value = 6;
+    }
+
     optional string string_value = 1;
     optional float float_value = 2;
     optional double double_value = 3;
@@ -43,6 +53,7 @@ message value {
     optional uint64 uint_value = 5;
     optional sint64 sint_value = 6;
     optional bool bool_value = 7;
+    optional Type type = 8 [default=string_value];
 }
 
 message coord_array {

--- a/index.js
+++ b/index.js
@@ -172,6 +172,10 @@ function _featureToGeobuf(geojson) {
                 value = v.toString();
                 valueType = 'string_value';
                 break;
+            case 'object':
+                value  = JSON.stringify(v);
+                valueType = 'string_value';
+                break;
         }
         property.value[valueType] = value;
         property.value.type = propertyValueType[valueType];
@@ -229,9 +233,19 @@ function _geobufToFeature(feature) {
 
     if (feature.id) { geojson.id = feature.id.value; }
 
+    var valueType, value;
     for (var i = 0; i < feature.properties.length; i++) {
-        var valueType = propertyValueTypeRev[feature.properties[i].value.type];
-        geojson.properties[feature.properties[i].key] = feature.properties[i].value[valueType];
+        valueType = propertyValueTypeRev[feature.properties[i].value.type];
+        value = feature.properties[i].value[valueType];
+        if (valueType == 'string_value'){
+            try {
+                value = JSON.parse(value);
+            }
+            catch(ex)  {
+                //do nothing, leave as string
+            }
+        }
+        geojson.properties[feature.properties[i].key] = value;
     }
 
     var geojsonGeometries = [];

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var ProtoBuf = require('protobufjs'),
+var protobuf = require('protocol-buffers'),
     assert = require('assert'),
     _ = require('underscore'),
     fs = require('fs');
@@ -8,17 +8,21 @@ module.exports.featureCollectionToGeobuf = featureCollectionToGeobuf;
 module.exports.geobufToFeature = geobufToFeature;
 module.exports.geobufToFeatureCollection = geobufToFeatureCollection;
 
-var Builder = ProtoBuf.loadProtoFile(__dirname + '/geobuf.proto');
-var geometryTypes = _.invert(Builder.build('geometry.Type'));
-var CoordArray = Builder.build('coord_array');
-var MultiArray = Builder.build('multi_array');
-var Property = Builder.build('property');
-var Value = Builder.build('value');
-var FeatureCollection = Builder.build('featurecollection');
-var Feature = Builder.build('feature');
-var Geometry = Builder.build('geometry');
-var GeometryType = Builder.build('geometry.Type');
-var Id = Builder.build('id');
+var Builder = protobuf(fs.readFileSync(__dirname + '/geobuf.proto'));
+var geobufJSON = Builder.toJSON();
+var structure = {};
+for (var i=0; i<geobufJSON.messages.length; i++){
+    structure[geobufJSON.messages[i].id] = geobufJSON.messages[i];
+}
+
+function _getEnumByID(enums, id){
+    return _.find(enums, function(e){return e.id == id});
+}
+
+var GeometryType = _getEnumByID(structure.geometry.enums, 'geometry.Type').values;
+var geometryTypes = _.invert(GeometryType);
+var propertyValueType = _getEnumByID(structure.value.enums, 'value.Type').values;
+var propertyValueTypeRev = _.invert(propertyValueType);
 
 var geotypeMap = {
     POINT: 'Point',
@@ -34,14 +38,14 @@ var geotypeMapRev = _.invert(geotypeMap);
 function featureCollectionToGeobuf(geojson) {
     assert.equal(geojson.type, 'FeatureCollection');
 
-    var b = Builder;
-    var featurecollection = new FeatureCollection();
-
+    var featurecollection = {
+        features: []
+    };
+    
     for (var i = 0; i < geojson.features.length; i++) {
-        featurecollection.add('features', _featureToGeobuf(geojson.features[i]));
+        featurecollection.features.push(_featureToGeobuf(geojson.features[i]));
     }
-
-    return featurecollection;
+    return Builder.featurecollection.encode(featurecollection);
 }
 
 function featureToGeobuf(geojson) {
@@ -59,111 +63,123 @@ function is_xyz(coords) {
     return false;
 }
 
+function _coordsToCoordArray(coords){
+    var i,j,
+        xyz = is_xyz(coords);
+    var coordArray = {
+        coords: [],
+        is_xyz: xyz
+    };
+    for (i = 0; i < coords.length; i++) {
+        if (xyz && coords[i].length == 2) coords[i].push(0);
+        for (j = 0; j < coords[i].length; j++) {
+            coordArray.coords.push(coords[i][j] * 1e6);
+        }
+    }
+    return coordArray;
+}
+
 function _featureToGeobuf(geojson) {
 
     assert.equal(geojson.type, 'Feature');
     assert.equal(typeof geojson.geometry, 'object');
 
-    var b = Builder;
-    var feature = new Feature();
+    var feature = {
+        geometries: [],
+        properties: []
+    };
 
     addGeometry(geojson.geometry);
 
     function addGeometry(inputGeom) {
+        var i, j, l, k, coordArray, xzy;
+
         if (inputGeom.type === 'GeometryCollection') {
-            for (var k = 0; k < inputGeom.geometries.length; k++) {
+            for (k = 0; k < inputGeom.geometries.length; k++) {
                 addGeometry(inputGeom.geometries[k]);
             }
             return;
         }
-        var geometry = new Geometry();
         var geometryTypes = GeometryType;
         if (geometryTypes[geotypeMapRev[inputGeom.type]] === undefined) {
             assert.fail('geometry type unknown', inputGeom.type);
         }
-        geometry.type = geometryTypes[geotypeMapRev[inputGeom.type]];
 
-        var i, j, l, k, coordArray, xzy;
+        var geometry = {
+            type: geometryTypes[geotypeMapRev[inputGeom.type]],
+            coord_array: [],
+            multi_array: []
+        };
+
         if (inputGeom.type === 'Point') {
-            coordArray = new CoordArray();
-            coordArray.set('is_xyz', (inputGeom.coordinates.length === 3));
+            coordArray = {
+                coords: [],
+                is_xyz: (inputGeom.coordinates.length === 3)
+            };
             for (i = 0; i < inputGeom.coordinates.length; i++) {
-                coordArray.add('coords', inputGeom.coordinates[i] * 1e6);
+                coordArray.coords.push(inputGeom.coordinates[i] * 1e6);
             }
-            geometry.add('coord_array', coordArray);
+            geometry.coord_array.push(coordArray);
         } else if (inputGeom.type === 'LineString' ||
                 inputGeom.type === 'MultiPoint') {
-            coordArray = new CoordArray();
-            xyz = is_xyz(inputGeom.coordinates);
-            coordArray.set('is_xyz', xyz);
-            for (i = 0; i < inputGeom.coordinates.length; i++) {
-                if (xyz && inputGeom.coordinates[i].length == 2) inputGeom.coordinates[i].push(0);
-                for (j = 0; j < inputGeom.coordinates[i].length; j++) {
-                    coordArray.add('coords', inputGeom.coordinates[i][j] * 1e6);
-                }
-            }
-            geometry.add('coord_array', coordArray);
+            geometry.coord_array.push(_coordsToCoordArray(inputGeom.coordinates));
         } else if (inputGeom.type === 'Polygon' ||
                   inputGeom.type === 'MultiLineString') {
             for (i = 0; i < inputGeom.coordinates.length; i++) {
-                coordArray = new CoordArray();
-                xyz = is_xyz(inputGeom.coordinates[i]);
-                coordArray.set('is_xyz', xyz);
-                for (j = 0; j < inputGeom.coordinates[i].length; j++) {
-                    if (xyz && inputGeom.coordinates[i][j].length == 2) inputGeom.coordinates[i][j].push(0);
-                    for (k = 0; k < inputGeom.coordinates[i][j].length; k++) {
-                        coordArray.add('coords', inputGeom.coordinates[i][j][k] * 1e6);
-                    }
-                }
-                geometry.add('coord_array', coordArray);
+                geometry.coord_array.push(_coordsToCoordArray(inputGeom.coordinates[i]));
             }
         } else if (inputGeom.type === 'MultiPolygon') {
+            var multiArray;
             for (i = 0; i < inputGeom.coordinates.length; i++) {
-                multiArray = new MultiArray();
+                multiArray = {
+                    arrays: []
+                };
                 for (j = 0; j < inputGeom.coordinates[i].length; j++) {
-                    coordArray = new CoordArray();
-                    xyz = is_xyz(inputGeom.coordinates[i][j]);
-                    coordArray.set('is_xyz', xyz);
-                    for (k = 0; k < inputGeom.coordinates[i][j].length; k++) {
-                        if (xyz && (inputGeom.coordinates[i][j][k].length === 2)) inputGeom.coordinates[i][j][k].push(0);
-                        for (l = 0; l < inputGeom.coordinates[i][j][k].length; l++) {
-                            coordArray.add('coords', inputGeom.coordinates[i][j][k][l] * 1e6);
-                        }
-                    }
-                    multiArray.add('arrays', coordArray);
+                    multiArray.arrays.push(_coordsToCoordArray(inputGeom.coordinates[i][j]));
                 }
-                geometry.add('multi_array', multiArray);
+                geometry.multi_array.push(multiArray);
             }
         }
-        feature.add('geometries', geometry);
+        
+        feature.geometries.push(geometry);
     }
 
     for (var k in geojson.properties) {
-        var p = new Property(),
-            val = new Value(),
-            v = geojson.properties[k];
+        var property = {key: k, value: {}},
+            v = geojson.properties[k],
+            value, valueType;
 
-        p.set('key', k);
         switch (typeof v) {
-            case 'number':
-                val.set('float_value',  v);
+            case 'number': 
+                value = v;
+                if (v|0 === v){
+                    if (v > 0) {
+                        valueType = 'uint_value';
+                    }
+                    else {
+                        valueType = 'sint_value';
+                    }
+                }
+                else {
+                    valueType = 'float_value';
+                }
                 break;
             case 'boolean':
-                val.set('bool_value',  v);
+                value = v;
+                valueType = 'bool_value';
                 break;
             case 'string':
-                val.set('string_value',  v.toString());
+                value = v.toString();
+                valueType = 'string_value';
                 break;
         }
-
-        p.set('value', val);
-        feature.add('properties', p);
+        property.value[valueType] = value;
+        property.value.type = propertyValueType[valueType];
+        feature.properties.push(property);
     }
 
     if (geojson.id) {
-        var id = new Id();
-        id.set('value', geojson.id.toString());
-        feature.set('id', id);
+        feature.id = {value: geojson.id};
     }
 
     return feature;
@@ -174,21 +190,36 @@ function geobufToFeature(buf) {
 }
 
 function geobufToFeatureCollection(buf) {
-    var b = Builder;
-    var featurecollection = FeatureCollection.decode(buf);
+    var featurecollection = Builder.featurecollection.decode(buf);
     var geojson = {
         type: 'FeatureCollection',
         features: []
     };
 
     for (var i = 0; i < featurecollection.features.length; i++) {
-        geojson.features.push(_geobufToFeature(featurecollection.features[i], b));
+        geojson.features.push(_geobufToFeature(featurecollection.features[i]));
     }
 
     return geojson;
 }
 
-function _geobufToFeature(feature, b) {
+function _coordArrayToCoords(coordArray, is_xyz){
+    var coords = [],
+        coord = [];
+    for (i = 0; i < coordArray.length; i++) {
+        coord.push(coordArray[i] / 1e6);
+        if (!is_xyz && coord.length === 2) {
+            coords.push(coord);
+            coord = [];
+        } else if (is_xyz && coord.length === 3) {
+            coords.push(coord);
+            coord = [];
+        }
+    }
+    return coords;
+}
+
+function _geobufToFeature(feature) {
 
     var geojson = {
         type: 'Feature',
@@ -199,9 +230,8 @@ function _geobufToFeature(feature, b) {
     if (feature.id) { geojson.id = feature.id.value; }
 
     for (var i = 0; i < feature.properties.length; i++) {
-        // inefficient!
-        geojson.properties[feature.properties[i].key] = _.find(
-            _.values(feature.properties[i].value), truthy);
+        var valueType = propertyValueTypeRev[feature.properties[i].value.type];
+        geojson.properties[feature.properties[i].key] = feature.properties[i].value[valueType];
     }
 
     var geojsonGeometries = [];
@@ -229,56 +259,24 @@ function _geobufToFeature(feature, b) {
         outputGeom.type = geotypeMap[geometryTypes[inputGeom.type]];
         if (outputGeom.type === 'Point') {
             for (i = 0; i < arr.coords.length; i++) {
-                outputGeom.coordinates.push(arr.coords[i].toNumber() / 1e6);
+                outputGeom.coordinates.push(arr.coords[i] / 1e6);
             }
         } else if (outputGeom.type === 'LineString' ||
             outputGeom.type === 'MultiPoint') {
-            var coord = [];
-            for (i = 0; i < arr.coords.length; i++) {
-                coord.push(arr.coords[i].toNumber() / 1e6);
-                if (!arr.is_xyz && coord.length === 2) {
-                    outputGeom.coordinates.push(coord);
-                    coord = [];
-                } else if (arr.is_xyz && coord.length === 3) {
-                    outputGeom.coordinates.push(coord);
-                    coord = [];
-                }
-            }
+            outputGeom.coordinates = _coordArrayToCoords(arr.coords, arr.is_xyz);
         } else if (outputGeom.type === 'Polygon' ||
             outputGeom.type === 'MultiLineString') {
-            var coord = [], ca = [];
             for (i = 0; i < inputGeom.coord_array.length; i++) {
-                ca = [];
-                for (j = 0; j < inputGeom.coord_array[i].coords.length; j++) {
-                    coord.push(inputGeom.coord_array[i].coords[j].toNumber() / 1e6);
-                    if (!inputGeom.coord_array[i].is_xyz && coord.length === 2) {
-                        ca.push(coord);
-                        coord = [];
-                    } else if (inputGeom.coord_array[i].is_xyz && coord.length === 3) {
-                        ca.push(coord);
-                        coord = [];
-                    }
-                }
-                outputGeom.coordinates.push(ca);
+                arr = inputGeom.coord_array[i];
+                outputGeom.coordinates.push(_coordArrayToCoords(arr.coords, arr.is_xyz));
             }
         } else if (outputGeom.type === 'MultiPolygon') {
-            var coord = [], ca = [], i, j, k;
+            // var coord = [], ca = [], i, j, k;
             for (i = 0; i < inputGeom.multi_array.length; i++) {
                 mca = [];
-
                 for (j = 0; j < inputGeom.multi_array[i].arrays.length; j++) {
-                    ca = [];
-                    for (k = 0; k < inputGeom.multi_array[i].arrays[j].coords.length; k++) {
-                        coord.push(inputGeom.multi_array[i].arrays[j].coords[k].toNumber() / 1e6);
-                        if (!inputGeom.multi_array[i].arrays[j].is_xyz && coord.length === 2) {
-                            ca.push(coord);
-                            coord = [];
-                        } else if (inputGeom.multi_array[i].arrays[j].is_xyz && coord.length === 3) {
-                            ca.push(coord);
-                            coord = [];
-                        }
-                    }
-                    mca.push(ca);
+                    arr = inputGeom.multi_array[i].arrays[j];
+                    mca.push(_coordArrayToCoords(arr.coords, arr.is_xyz));
                 }
                 outputGeom.coordinates.push(mca);
             }
@@ -288,8 +286,4 @@ function _geobufToFeature(feature, b) {
     }
 
     return geojson;
-}
-
-function truthy(val) {
-    return val !== null;
 }

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -12,7 +12,8 @@ var feat = {
     properties: {
         name: 'Hello world',
         b: 2,
-        thing: true
+        thing: true,
+        nested: {nope: 'yep'}
     }
 };
 
@@ -46,7 +47,19 @@ test('geobufToFeature', function(t) {
 test('featurecollection', function(t) {
     for (var k in geojsonFixtures.featurecollection) {
         var ex = geojsonFixtures.featurecollection[k];
-        t.ok(geobuf.featureCollectionToGeobuf(ex), k);
+        var buf = geobuf.featureCollectionToGeobuf(ex);
+        t.ok(buf, k);
+
+        var out = geobuf.geobufToFeatureCollection(buf);
+        if (buf.length < 1000){
+            t.deepEqual(out, ex, k);
+        }
+        else {
+            //too many features to do diff if deep compare fails, only test a few
+            for (var i=0; i<Math.min(2, out.features.length); i++){
+                t.deepEqual(out.features[i],  ex.features[i], k + ': feature ' + i);
+            }
+        }
     }
     t.end();
 });

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -35,18 +35,18 @@ test('featureToGeobuf - throws', function(t) {
 test('geobufToFeature', function(t) {
     for (var k in geojsonFixtures.geometry) {
         var ex = _.extend({}, feat, { geometry: geojsonFixtures.geometry[k] });
-        t.comment(k + ': ' + geobuf.featureToGeobuf(ex).encode().toBuffer().length);
-        t.deepEqual(geobuf.geobufToFeature(geobuf.featureToGeobuf(ex).encode()), ex, k);
+        t.comment(k + ': ' + geobuf.featureToGeobuf(ex).length);
+        t.deepEqual(geobuf.geobufToFeature(geobuf.featureToGeobuf(ex)), ex, k);
     }
     var withId = _.extend({id: 'i-can-haz-id'}, feat, { geometry: geojsonFixtures.geometry[k] });
-    t.deepEqual(geobuf.geobufToFeature(geobuf.featureToGeobuf(withId).encode()), withId, k + 'with id');
+    t.deepEqual(geobuf.geobufToFeature(geobuf.featureToGeobuf(withId)), withId, k + 'with id');
     t.end();
 });
 
 test('featurecollection', function(t) {
     for (var k in geojsonFixtures.featurecollection) {
         var ex = geojsonFixtures.featurecollection[k];
-        t.ok(geobuf.featureCollectionToGeobuf(ex).encode(), k);
+        t.ok(geobuf.featureCollectionToGeobuf(ex), k);
     }
     t.end();
 });


### PR DESCRIPTION
This PR resolves #10 and #16.  In my own tests, this is faster than the prior implementation but produces files a little bigger.

The API for protocol-buffers is a bit different than for ```protobufjs```; this required rewriting most of the touch points to objects created via ```protobufjs```.

The biggest change required was the addition of an enum-based field to ```geobuf.proto``` to track the value type of a property's value.  This is because ```protocol-buffers``` returns default values for all value types (e.g., ```''``` for strings and ```0``` for numeric types instead of ```null```), which made it much more difficult to introspect the values themselves to determine type (because ```''``` may indicate the actual value if it was originally a string type but blank, and not just indicate default).  This adds a bit of extra size to the final geobuf.  I've got some ideas on how this could be handled but will save those for future PRs (some ideas require bigger changes to ```geobuf.proto```).  Right now it is marked as ```optional``` but is expected for decoding (so effectively ```required```).  I did not add a shim for decoding geobufs that lack this.

While I was at it, I consolidated duplicate code used in the loops over coordinates.

I updated the tests, but did not push updates to ```bench.js``` (it seemed wrapped around a pretty specific benchmark).

Overall I tried to stick to the overall code style already in use.  