### PR TITLE
Change protobuf url to the github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A [compact encoding](geobuf.proto) for geographic data.
 
 Like [vector-tile-spec](https://github.com/mapbox/vector-tile-spec),
-this is a [protobuf](http://code.google.com/p/protobuf/)-based encoding.
+this is a [protobuf](https://github.com/google/protobuf/)-based encoding.
 
 Unlike vector-tile-spec, this deals with untiled data in native projections.
 


### PR DESCRIPTION
They've moved from Google Code to Github.