### PR TITLE
JSON-LD proofing

### DIFF
--- a/test/fixtures/props.json
+++ b/test/fixtures/props.json
@@ -1,4 +1,12 @@
 {
+    "@context": {
+        "Feature": "http://example.com/vocab#Feature",
+        "datetime": {
+            "@id": "http://www.w3.org/2006/time#inXSDDateTime",
+            "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "when": "http://example.com/vocab#when"
+    },
     "type": "FeatureCollection",
     "foo": "bar",
     "features": [{
@@ -24,7 +32,12 @@
         }
     }, {
         "type": "Feature",
+        "@type": "Feature",
         "id": "foo",
+        "when": {
+            "datetime": "2014-04-24",
+            "@type": "Instant"
+        },
         "geometry": {
             "type": "Point",
             "coordinates": [100.0, 0.0]


### PR DESCRIPTION
Add @context, @type, and when to props.json. Asserting that geobuf can round trip GeoJSON with JSON-LD.

Closes #38.