### PR TITLE
Streamable, flatlined geobuf format revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ it may still change as we get community feedback and discover new ways to improv
                     | normal    | gzipped
 ------------------- | --------- | --------
 us-zips.json 	    | 101.85 MB | 26.67 MB
-us-zips.pbf         | 12.24 MB  | 10.48 MB
+us-zips.pbf         | 12.2 MB   | 10.31 MB
 idaho.json          | 10.92 MB  | 2.57 MB
-idaho.pbf           | 1.37 MB   | 1.17 MB
+idaho.pbf           | 1.38 MB   | 1.18 MB
 
 ## API
 

--- a/decode.js
+++ b/decode.js
@@ -4,76 +4,70 @@ module.exports = decode;
 
 var keys, values, lengths, dim, e;
 
-var geometryTypes = ['Point', 'MultiPoint', 'LineString', 'MultiLineString',
-                      'Polygon', 'MultiPolygon', 'GeometryCollection'];
+var objTypes = ['Point', 'MultiPoint', 'LineString', 'MultiLineString',
+                      'Polygon', 'MultiPolygon', 'GeometryCollection', 'Feature', 'FeatureCollection'];
 
 function decode(pbf) {
     dim = 2;
     e = Math.pow(10, 6);
-    lengths = null;
 
     keys = [];
     values = [];
-    var obj = pbf.readFields(readDataField, {});
-    keys = null;
 
-    return obj;
-}
+    var lastFeatureCol,
+        lastFeature,
+        lastGeometryCol;
 
-function readDataField(tag, obj, pbf) {
-    if (tag === 1) keys.push(pbf.readString());
-    else if (tag === 2) dim = pbf.readVarint();
-    else if (tag === 3) e = Math.pow(10, pbf.readVarint());
+    var root;
 
-    else if (tag === 4) readFeatureCollection(pbf, obj);
-    else if (tag === 5) readFeature(pbf, obj);
-    else if (tag === 6) readGeometry(pbf, obj);
-}
+    while (pbf.pos < pbf.length) {
+        var obj = pbf.readMessage(readObjectField, {});
+        if (!root) root = obj;
 
-function readFeatureCollection(pbf, obj) {
-    obj.type = 'FeatureCollection';
-    obj.features = [];
-    return pbf.readMessage(readFeatureCollectionField, obj);
-}
+        if (obj.type === 'FeatureCollection') {
+            obj.features = [];
 
-function readFeature(pbf, feature) {
-    feature.type = 'Feature';
-    return pbf.readMessage(readFeatureField, feature);
-}
+            lastFeatureCol = obj;
 
-function readGeometry(pbf, geom) {
-    return pbf.readMessage(readGeometryField, geom);
-}
+        } else if (obj.type === 'Feature') {
+            if (lastFeatureCol) lastFeatureCol.features.push(obj);
 
-function readFeatureCollectionField(tag, obj, pbf) {
-    if (tag === 1) obj.features.push(readFeature(pbf, {}));
+            lastGeometryCol = null;
+            lastFeature = obj;
 
-    else if (tag === 13) values.push(readValue(pbf));
-    else if (tag === 15) readProps(pbf, obj);
-}
+        } else {
+            if (lastGeometryCol) lastGeometryCol.geometries.push(obj);
+            else if (lastFeature) lastFeature.geometry = obj;
 
-function readFeatureField(tag, feature, pbf) {
-    if (tag === 1) feature.geometry = readGeometry(pbf, {});
+            if (obj.type === 'GeometryCollection') {
+                obj.geometries = [];
 
-    else if (tag === 11) feature.id = pbf.readString();
-    else if (tag === 12) feature.id = pbf.readSVarint();
-
-    else if (tag === 13) values.push(readValue(pbf));
-    else if (tag === 14) feature.properties = readProps(pbf, {});
-    else if (tag === 15) readProps(pbf, feature);
-}
-
-function readGeometryField(tag, geom, pbf) {
-    if (tag === 1) geom.type = geometryTypes[pbf.readVarint()];
-
-    else if (tag === 2) lengths = pbf.readPackedVarint();
-    else if (tag === 3) readCoords(geom, pbf, geom.type);
-    else if (tag === 4) {
-        geom.geometries = geom.geometries || [];
-        geom.geometries.push(readGeometry(pbf, {}));
+                lastGeometryCol = obj;
+            }
+        }
     }
+
+    keys = null;
+    lengths = null;
+
+    return root;
+}
+
+function readObjectField(tag, obj, pbf) {
+    if (tag === 1) obj.type = objTypes[pbf.readVarint()];
+    else if (tag === 3) dim = pbf.readVarint();
+    else if (tag === 4) e = Math.pow(10, pbf.readVarint());
+    else if (tag === 5) keys.push(pbf.readString());
+
+    else if (tag === 6) lengths = pbf.readPackedVarint();
+    else if (tag === 7) readCoords(obj, pbf, obj.type);
+
+    else if (tag === 8) obj.id = pbf.readString();
+    else if (tag === 9) obj.id = pbf.readSVarint();
+
     else if (tag === 13) values.push(readValue(pbf));
-    else if (tag === 15) readProps(pbf, geom);
+    else if (tag === 14) obj.properties = readProps(pbf, {});
+    else if (tag === 15) readProps(pbf, obj);
 }
 
 function readCoords(geom, pbf, type) {

--- a/encode.js
+++ b/encode.js
@@ -3,16 +3,19 @@
 module.exports = encode;
 
 var keys, keysNum, dim, e,
+    paramsWritten = false,
     maxPrecision = 1e6;
 
-var geometryTypes = {
+var objTypes = {
     'Point': 0,
     'MultiPoint': 1,
     'LineString': 2,
     'MultiLineString': 3,
     'Polygon': 4,
     'MultiPolygon': 5,
-    'GeometryCollection': 6
+    'GeometryCollection': 6,
+    'Feature': 7,
+    'FeatureCollection': 8
 };
 
 function encode(obj, pbf) {
@@ -22,21 +25,12 @@ function encode(obj, pbf) {
     e = 1;
 
     analyze(obj);
-
     e = Math.min(e, maxPrecision);
-    var precision = Math.ceil(Math.log(e) / Math.LN10);
 
-    var keysArr = Object.keys(keys);
-
-    for (var i = 0; i < keysArr.length; i++) pbf.writeStringField(1, keysArr[i]);
-    if (dim !== 2) pbf.writeVarintField(2, dim);
-    if (precision !== 6) pbf.writeVarintField(3, precision);
-
-    if (obj.type === 'FeatureCollection') pbf.writeMessage(4, writeFeatureCollection, obj);
-    else if (obj.type === 'Feature') pbf.writeMessage(5, writeFeature, obj);
-    else pbf.writeMessage(6, writeGeometry, obj);
+    writeObjects(obj, pbf);
 
     keys = null;
+    paramsWritten = false;
 
     return pbf.finish();
 }
@@ -95,41 +89,52 @@ function saveKey(key) {
     if (keys[key] === undefined) keys[key] = keysNum++;
 }
 
-function writeFeatureCollection(obj, pbf) {
-    for (var i = 0; i < obj.features.length; i++) {
-        pbf.writeMessage(1, writeFeature, obj.features[i]);
+function writeObjects(obj, pbf) {
+    pbf.writeRawMessage(writeObject, obj);
+
+    var i;
+
+    if (obj.type === 'FeatureCollection') {
+        for (i = 0; i < obj.features.length; i++) writeObjects(obj.features[i], pbf);
+
+    } else if (obj.type === 'Feature') {
+        if (obj.geometry) writeObjects(obj.geometry, pbf);
+
+    } else if (obj.type === 'GeometryCollection' && obj.geometries) {
+        for (i = 0; i < obj.geometries.length; i++) writeObjects(obj.geometries[i], pbf);
     }
+}
+
+function writeObject(obj, pbf) {
+    pbf.writeVarintField(1, objTypes[obj.type]);
+
+    if (!paramsWritten) {
+        var precision = Math.ceil(Math.log(e) / Math.LN10);
+
+        pbf.writeBooleanField(2, true);
+        if (dim !== 2) pbf.writeVarintField(3, dim);
+        if (precision !== 6) pbf.writeVarintField(4, precision);
+        for (var id in keys) pbf.writeStringField(5, id);
+
+        paramsWritten = true;
+    }
+
+    var coords = obj.coordinates;
+
+    if (obj.type === 'Point') writePoint(coords, pbf);
+    else if (obj.type === 'MultiPoint') writeLine(coords, pbf, true);
+    else if (obj.type === 'LineString') writeLine(coords, pbf);
+    else if (obj.type === 'MultiLineString') writeMultiLine(coords, pbf);
+    else if (obj.type === 'Polygon') writeMultiLine(coords, pbf, true);
+    else if (obj.type === 'MultiPolygon') writeMultiPolygon(coords, pbf);
+
+    if (obj.id !== undefined) {
+        if (typeof obj.id === 'number' && obj.id % 1 === 0) pbf.writeSVarintField(9, obj.id);
+        else pbf.writeStringField(8, obj.id);
+    }
+
+    if (obj.properties) writeProps(obj.properties, pbf);
     writeProps(obj, pbf, true);
-}
-
-function writeFeature(feature, pbf) {
-    pbf.writeMessage(1, writeGeometry, feature.geometry);
-
-    if (feature.id !== undefined) {
-        if (typeof feature.id === 'number' && feature.id % 1 === 0) pbf.writeSVarintField(12, feature.id);
-        else pbf.writeStringField(11, feature.id);
-    }
-
-    if (feature.properties) writeProps(feature.properties, pbf);
-    writeProps(feature, pbf, true);
-}
-
-function writeGeometry(geom, pbf) {
-    pbf.writeVarintField(1, geometryTypes[geom.type]);
-
-    var coords = geom.coordinates;
-
-    if (geom.type === 'Point') writePoint(coords, pbf);
-    else if (geom.type === 'MultiPoint') writeLine(coords, pbf, true);
-    else if (geom.type === 'LineString') writeLine(coords, pbf);
-    else if (geom.type === 'MultiLineString') writeMultiLine(coords, pbf);
-    else if (geom.type === 'Polygon') writeMultiLine(coords, pbf, true);
-    else if (geom.type === 'MultiPolygon') writeMultiPolygon(coords, pbf);
-    else if (geom.type === 'GeometryCollection') {
-        for (var i = 0; i < geom.geometries.length; i++) pbf.writeMessage(4, writeGeometry, geom.geometries[i]);
-    }
-
-    writeProps(geom, pbf, true);
 }
 
 function writeProps(props, pbf, isCustom) {
@@ -169,13 +174,13 @@ function writeValue(value, pbf) {
 function writePoint(point, pbf) {
     var coords = [];
     for (var i = 0; i < dim; i++) coords.push(Math.round(point[i] * e));
-    pbf.writePackedSVarint(3, coords);
+    pbf.writePackedSVarint(7, coords);
 }
 
 function writeLine(line, pbf) {
     var coords = [];
     populateLine(coords, line);
-    pbf.writePackedSVarint(3, coords);
+    pbf.writePackedSVarint(7, coords);
 }
 
 function writeMultiLine(lines, pbf, closed) {
@@ -184,12 +189,12 @@ function writeMultiLine(lines, pbf, closed) {
     if (len !== 1) {
         var lengths = [];
         for (i = 0; i < len; i++) lengths.push(lines[i].length - (closed ? 1 : 0));
-        pbf.writePackedVarint(2, lengths);
+        pbf.writePackedVarint(6, lengths);
         // TODO faster with custom writeMessage?
     }
     var coords = [];
     for (i = 0; i < len; i++) populateLine(coords, lines[i], closed);
-    pbf.writePackedSVarint(3, coords);
+    pbf.writePackedSVarint(7, coords);
 }
 
 function writeMultiPolygon(polygons, pbf) {
@@ -201,14 +206,14 @@ function writeMultiPolygon(polygons, pbf) {
             lengths.push(polygons[i].length);
             for (j = 0; j < polygons[i].length; j++) lengths.push(polygons[i][j].length - 1);
         }
-        pbf.writePackedVarint(2, lengths);
+        pbf.writePackedVarint(6, lengths);
     }
 
     var coords = [];
     for (i = 0; i < len; i++) {
         for (j = 0; j < polygons[i].length; j++) populateLine(coords, polygons[i][j], true);
     }
-    pbf.writePackedSVarint(3, coords);
+    pbf.writePackedSVarint(7, coords);
 }
 
 function populateLine(coords, line, closed) {

--- a/geobuf.proto
+++ b/geobuf.proto
@@ -1,56 +1,38 @@
-option optimize_for = LITE_RUNTIME;
+message Object {
+    required ObjectType type = 1;
 
-message Data {
-    repeated string keys = 1; // global arrays of unique keys
+    optional bool is_top_level = 2;
 
-    optional uint32 dimensions = 2 [default = 2]; // max coordinate dimensions
-    optional uint32 precision = 3 [default = 6]; // number of digits after decimal point for coordinates
+    // global parameters; encoded in the top level object, with subsequent objects inheriting them
+    optional uint32 dimensions = 3 [default = 2]; // max coordinate dimensions
+    optional uint32 precision = 4 [default = 6]; // number of digits after decimal point for coordinates
+    repeated string keys = 5; // global array of unique keys
 
-    oneof data_type {
-        FeatureCollection feature_collection = 4;
-        Feature feature = 5;
-        Geometry geometry = 6;
+    // geometry coordinates (where the bulk of the size goes)
+    repeated uint32 lengths = 6 [packed = true]; // coordinate structure in lengths
+    repeated sint64 coords = 7 [packed = true]; // delta-encoded integer values
+
+    oneof id_type {
+        string id = 8;
+        sint64 int_id = 9;
     }
 
-    message Feature {
-        required Geometry geometry = 1;
+    repeated Value values = 13; // unique values
 
-        oneof id_type {
-            string id = 11;
-            sint64 int_id = 12;
-        }
+    repeated uint32 properties = 14 [packed = true]; // pairs of key/value indexes for feature properties
+    repeated uint32 custom_properties = 15 [packed = true]; // arbitrary properties
 
-        repeated Value values = 13; // unique values
-        repeated uint32 properties = 14 [packed = true]; // pairs of key/value indexes
-        repeated uint32 custom_properties = 15 [packed = true]; // arbitrary properties
-    }
+    enum ObjectType {
+        POINT = 0;
+        MULTIPOINT = 1;
+        LINESTRING = 2;
+        MULTILINESTRING = 3;
+        POLYGON = 4;
+        MULTIPOLYGON = 5;
+        GEOMETRYCOLLECTION = 6;
 
-    message Geometry {
-        required Type type = 1;
-
-        repeated uint32 lengths = 2 [packed = true]; // coordinate structure in lengths
-        repeated sint64 coords = 3 [packed = true]; // delta-encoded integer values
-        repeated Geometry geometries = 4;
-
-        repeated Value values = 13;
-        repeated uint32 custom_properties = 15 [packed = true];
-
-        enum Type {
-            POINT = 0;
-            MULTIPOINT = 1;
-            LINESTRING = 2;
-            MULTILINESTRING = 3;
-            POLYGON = 4;
-            MULTIPOLYGON = 5;
-            GEOMETRYCOLLECTION = 6;
-        }
-    }
-
-    message FeatureCollection {
-        repeated Feature features = 1;
-
-        repeated Value values = 13;
-        repeated uint32 custom_properties = 15 [packed = true];
+        FEATURE = 7;
+        FEATURECOLLECTION = 8;
     }
 
     message Value {


### PR DESCRIPTION
A new fomat revision to enable the possibility of streaming reads and writes, discussed at #37.

The encoding/decoding implementation here isn't streaming — I think this is a task for a separate repo (`geobuf-stream`). The spec should also be in a separate `geobuf-spec` repo.

The current Geobuf encodes nested protobuf messages to reflect the GeoJSON structure (with nested objects, e.g. FeatureCollection with a bunch of Features, each having a Geometry or GeometryCollection with a bunch of geometries). The idea behind the new one is that basically things are encoded in a flat way like this:

```bash
FeatureCol # (top level)
Feature # child of FeatureCol
GeometryCol # child of Feature
Geometry # child of GeometryCol
Geometry # child of GeometryCol
Feature # child of FeatureCol
Geometry # child of Feature
Feature # (top level)
Geometry # child of Feature
```

The nature of nesting in GeoJSON allows us to derive the structure, e.g. Feature can only belong to a FeatureCollection (so if it follows one, it’s a child). 

This flat way of encoding makes streaming and partial reads and writes much easier while simplifying the format itself significantly.

To support streaming multiple GeoJSON datasets and concatenating Geobufs, there's a `is_top_level` field to indicate whether an encoded object is the root of a different GeoJSON object (rather than a child of previous one).

The only case we’re dropping is support of GeometryCollection within another GeometryCollection which @sgillies called bullshit and said we can safely not support. 

Here's the new schema proto: https://github.com/mapbox/geobuf/blob/stream/geobuf.proto

- [x] update schema
- [x] update encoding
- [x] update decoding
- [ ] get some feedback
- [ ] update changelog
- [ ] release 2.0.0