### PR TITLE
note required node version for Buffer.from

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ var buffer = geobuf.encode(geojson, new Pbf());
 ```
 
 Given a GeoJSON object and a [Pbf](https://github.com/mapbox/pbf) object to write to,
-returns a Geobuf as `UInt8Array` arrya of bytes.
-In Node, you can use `Buffer.from` to convert back to a buffer.
+returns a Geobuf as `UInt8Array` array of bytes.
+In Node@4.5.0 or later, you can use `Buffer.from` to convert back to a buffer.
 
 ### decode
 


### PR DESCRIPTION
`Buffer.from` changed in `node@4.5.0` to add support for [ArrayBuffers](https://nodejs.org/dist/v4.5.0/docs/api/buffer.html#buffer_class_method_buffer_from_arraybuffer), before that it only handled [Arrays](https://nodejs.org/dist/v4.5.0/docs/api/buffer.html#buffer_class_method_buffer_from_array).

/cc @mourner 