### PR TITLE
Allow for null geometries in features

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -39,7 +39,9 @@ function readFeatureCollection(pbf, obj) {
 
 function readFeature(pbf, feature) {
     feature.type = 'Feature';
-    return pbf.readMessage(readFeatureField, feature);
+    var f = pbf.readMessage(readFeatureField, feature);
+    if (!f.hasOwnProperty('geometry')) f.geometry = null;
+    return f;
 }
 
 function readGeometry(pbf, geom) {

--- a/encode.js
+++ b/encode.js
@@ -47,7 +47,7 @@ function analyze(obj) {
         for (i = 0; i < obj.features.length; i++) analyze(obj.features[i]);
 
     } else if (obj.type === 'Feature') {
-        analyze(obj.geometry);
+        if (obj.geometry !== null) analyze(obj.geometry);
         for (key in obj.properties) saveKey(key);
 
     } else if (obj.type === 'Point') analyzePoint(obj.coordinates);
@@ -98,7 +98,7 @@ function writeFeatureCollection(obj, pbf) {
 }
 
 function writeFeature(feature, pbf) {
-    pbf.writeMessage(1, writeGeometry, feature.geometry);
+    if (feature.geometry !== null) pbf.writeMessage(1, writeGeometry, feature.geometry);
 
     if (feature.id !== undefined) {
         if (typeof feature.id === 'number' && feature.id % 1 === 0) pbf.writeSVarintField(12, feature.id);

--- a/test/fixtures/issue55.json
+++ b/test/fixtures/issue55.json
@@ -1,0 +1,25 @@
+{
+"type": "FeatureCollection", "features": 
+  [{
+    "type": "Feature",
+    "properties": {"miles hiked  ": 12},
+    "geometry": {
+      "type": "LineString",
+      "coordinates": [
+        [-1.1, 2.1],
+        [2, -999.9]
+      ]
+    }
+  },{
+    "type": "Feature",
+    "properties": {"  profit": -999.9},
+    "geometry": null
+  },{
+    "type": "Feature",
+    "properties": {"miles hiked  ": 13.1},
+    "geometry": {
+      "type": "Point",
+      "coordinates": [0.0001, -0.0001]
+    }
+  }]
+}

--- a/test/validate.test.js
+++ b/test/validate.test.js
@@ -15,6 +15,7 @@ for (var name in geojsonFixtures) {
 test('roundtrip issue', roundtripTest(getJSON('issue62.json')));
 
 test('roundtrip custom properties', roundtripTest(getJSON('props.json')));
+test('roundtrip issue55', roundtripTest(getJSON('issue55.json')));
 test('roundtrip issue90', roundtripTest(getJSON('issue90.json')));
 test('roundtrip single-ring MultiPolygon', roundtripTest(getJSON('single-multipoly.json')));
 


### PR DESCRIPTION
Attempt at resolving #55

Despite geometry being set as `required` in the Feature message in geobuf.proto, it appears that not setting it removes it successfully from the serialized message without complaint. The generated protobuf file is interpreted without issue using both pbf and google protobuffers (e.g. a simple display in Python via:
```import sys
import geobuf_pb2

f = open("issue55.pb", "rb")
data = geobuf_pb2.Data()
data.ParseFromString(f.read())
print(data)
```
where geobuf_pb2 was generated by `protoc` using geobuf.proto.

The absence of a message field is a natural and efficient way to encode a null message in protobuf IMHO.  

Despite testing suggesting that the approach pursued here is valid, it would be preferable before merging this approach to update geobuf.proto to make the geometry field in Feature messages optional.