### PR TITLE
feature: encode null property values more efficiently

### DIFF
--- a/encode.js
+++ b/encode.js
@@ -143,6 +143,8 @@ function writeProps(props, pbf, isCustom) {
 }
 
 function writeValue(value, pbf) {
+    if (value === null) return;
+
     var type = typeof value;
 
     if (type === 'string') pbf.writeStringField(1, value);


### PR DESCRIPTION
geobuf currently encodes any property with a `null` value as a `json_value: "[null]"` in the protobuf Value messages. 

Since Value makes use of a `oneof value_type`, it is permissible to allow missing (unset) `value_type`s. Making use of these to encode null property values is a trivial and logical optimisation that reduces the size of serialized geobuf messages that contain such fields.

With this change the size of the `test/fixutres/issue90.json` that contains 4 null properties is reduced from 117 bytes to 99 bytes. This optimisation can make a difference in real-world datasets, for example the [Invasive_Species.geojson](http://geodata.vermont.gov/datasets/b1ae7b7b110447c3b452d9cacffeed36_174.geojson) geobuf (using default precision=6) shrinks from  266877 bytes to 218505 with this update (although admittedly following gzip compression the saving is modest: from 34862 bytes to 34119 ... yes this dataset is very amenable to compression via gzip!).