### PR TITLE
Improve handling default enum values

### DIFF
--- a/decode.js
+++ b/decode.js
@@ -45,6 +45,7 @@ function readFeature(pbf, feature) {
 }
 
 function readGeometry(pbf, geom) {
+    geom.type = 'Point';
     return pbf.readMessage(readGeometryField, geom);
 }
 


### PR DESCRIPTION
This merge request provides a fix for the problems highlighted in #77.

By default, Protobuf libraries do not encode first enum values. If the value is missing when decoded, those libraries assume the first enum value as default. According to [https://developers.google.com/protocol-buffers/docs/proto3#default](https://developers.google.com/protocol-buffers/docs/proto3#default):

> "For enums, the default value is the first defined enum value, which must be 0."

The problem is observed when trying to pass valid PBFs to the decode function that were not first encoded by geobuf.js but by another library (e.g. pygeobuf). The readCoords function is checking for type, which if it's a POINT, is undefined. Obviously, this impacts anything expecting valid GeoJSON.

The update to the ``readGeometry`` function adds behaviour similar to the functions above it (``readFeatureCollection`` and ``readFeature``) which set a default value. This solves the symptom observed in the ``readCoords`` function (captured in #77) by ensuring that the ``geom.type`` is not undefined.
