### PR TITLE
Fix shp2geobuf

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,12 +92,22 @@ Installs these nifty binaries:
 
 * `geobuf2json`: turn Geobuf from `stdin` or specified file to GeoJSON on `stdout`
 * `json2geobuf`: turn GeoJSON from `stdin` or specified file to Geobuf on `stdout`
-* `shp2geobuf`: given a Shapefile filename, send Geobuf on `stdout`
+* `shp2geobuf`: given a Shapefile (.shp) filename, send Geobuf on `stdout`
 
 ```bash
 json2geobuf data.json > data.pbf
-shp2geobuf myshapefile > data.pbf
 geobuf2json data.pbf > data.json
+
+# if an optional .dbf file exists under the same basename in the 
+# same directory, it will be found automatically and included.
+shp2geobuf myshapefile.shp > data.pbf  # Example: myshapefile.dbf
+
+# Or specify the dbf location explicitly if desired:
+shp2geobuf myshapefile.shp /path/to/my_dbf_file.dbf > data.pbf
+
+# Using pipes 
+cat data.json | json2geobuf > data.pbf
+cat data.pbf | geobuf2json > data.json 
 ```
 
 Note that for big files, `geobuf2json` command can be pretty slow, but the bottleneck is not the decoding,

--- a/bin/shp2geobuf
+++ b/bin/shp2geobuf
@@ -2,9 +2,47 @@
 
 var encode = require('../encode'),
     Pbf = require('pbf'),
-    shapefile = require('shapefile');
+    shapefile = require('shapefile'),
     fs = require('fs'),
-    concat = require('concat-stream');
+    path = require('path');
 
 
-shapefile.read(process.argv[2], process.argv[3]);
+var shp_path = process.argv[2];
+
+var dbf_path = process.argv[3] === undefined ?
+               path.dirname(shp_path) + '/' + path.basename(shp_path, '.shp') + '.dbf'
+               : process.argv[3];
+var shp_name = path.basename(shp_path);
+var dbf_name = path.basename(dbf_path);
+var dbf_exists = true;
+
+fs.access(shp_path, fs.F_OK, (err) => {
+  if (err) {
+    console.error('File %s does not exist!', shp_path);
+    process.exit(1);
+  }
+});
+
+// Check for associated dbf file
+fs.access(dbf_path, fs.F_OK, (err) => {
+  if (err) {
+    dbf_exists = false;
+  }
+})
+  
+
+if(dbf_exists === true)
+{
+    shapefile.read(shp_path, dbf_path).then(function(geojson){
+    var geobuf = encode(geojson, new Pbf());
+    var output_buffer = Buffer.allocUnsafe ? Buffer.from(geobuf) : new Buffer(geobuf);
+    process.stdout.write(output_buffer);
+    });
+}
+else
+{
+    shapefile.read(shp_path).then(function(geojson){
+    var geobuf = encode(geojson, new Pbf());
+    var output_buffer = Buffer.allocUnsafe ? Buffer.from(geobuf) : new Buffer(geobuf);
+    process.stdout.write(output_buffer);
+}

--- a/bin/shp2geobuf
+++ b/bin/shp2geobuf
@@ -3,7 +3,8 @@
 var encode = require('../encode'),
     Pbf = require('pbf'),
     shapefile = require('shapefile');
+    fs = require('fs'),
+    concat = require('concat-stream');
 
-shapefile.read(process.argv[2], function(err, geojson) {
-    process.stdout.write(encode(geojson, new Pbf()));
-});
+
+shapefile.read(process.argv[2], process.argv[3]);


### PR DESCRIPTION
Hi, I am not very comfortable with javascript so to be perfectly honest, this rewrite is probably pretty bad in terms of code quality.  This pull request is more for other people to find, or perhaps the original authors to take implementation ideas from, rather than being merged in actuality.  

Anyway, shp2geobuf doesn't work at all.  It can't seem to open the stream at all, at least on POSIX systems.  Beyond that, it will only import a .shp file and ignore the associated .dbf file, if it exists.  

This is an attempt at both fixing shp2geobuf, and adding some fairly important functionality.  It can find .dbf files automatically as long as they have the same basename as the .shp file and are located in the same directory.  And the user may also give a path to a .dbf file explicitly as a second argument.  And of course, it will still work with a .shp file by itself.  

I also updated the documentation to reflect this, as well as the ability to pipe data to geobuf2json and json2geobuf.  Neither of these commands seem to work anymore on POSIX systems if you specify a file path, but they do still work if you have them read from stdin.  

Again, this code probably sucks so I don't expect anyone to actually merge this in, but if anyone who actually knows what they're doing in javascript wants to use/adapt/base their implementation on this code, by all means.  I waive all claim of copyright on any work included in this pull request. 

Thanks!