### PR TITLE
Fix shp2geobuf

### DIFF
--- a/bin/shp2geobuf
+++ b/bin/shp2geobuf
@@ -1,9 +1,10 @@
 #!/usr/bin/env node
 
 var encode = require('../encode'),
-    Pbf = require('pbf'),
-    shapefile = require('shapefile');
+  Pbf = require('pbf'),
+  shapefile = require('shapefile')
 
-shapefile.read(process.argv[2], function(err, geojson) {
-    process.stdout.write(encode(geojson, new Pbf()));
-});
+shapefile.read(process.argv[2]).then(geojson => {
+  const encoded = encode(geojson, new Pbf())
+  process.stdout.write(Buffer.from(encoded))
+})


### PR DESCRIPTION
This PR updates the arguments passed to shapefile.read and uses the promise returned instead of expecting a callback.