### PR TITLE
Add back stripped tags like Geometry lengths, dimensions and precision

### DIFF
--- a/bin/json2geobufb64
+++ b/bin/json2geobufb64
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+
+var encode = require('../encode'),
+    Pbf = require('pbf'),
+    fs = require('fs'),
+    concat = require('concat-stream');
+
+var input = process.stdin.isTTY ? fs.createReadStream(process.argv[2]) : process.stdin;
+
+input.pipe(concat(function(buf) {
+    var geojson = JSON.parse(buf.toString());
+
+    var pbf = encode(geojson, new Pbf());
+    var buffer = Buffer.allocUnsafe ? Buffer.from(pbf) : new Buffer(pbf);
+    var test = buffer.toString("base64");
+
+    process.stdout.write(test);
+}));

--- a/encode.js
+++ b/encode.js
@@ -28,8 +28,8 @@ function encode(obj, pbf) {
     var precision = Math.ceil(Math.log(e) / Math.LN10);
 
     for (var i = 0; i < keysArr.length; i++) pbf.writeStringField(1, keysArr[i]);
-    if (dim !== 2) pbf.writeVarintField(2, dim);
-    if (precision !== 6) pbf.writeVarintField(3, precision);
+    pbf.writeVarintField(2, dim);
+    pbf.writeVarintField(3, precision);
 
     if (obj.type === 'FeatureCollection') pbf.writeMessage(4, writeFeatureCollection, obj);
     else if (obj.type === 'Feature') pbf.writeMessage(5, writeFeature, obj);
@@ -172,12 +172,12 @@ function writeLine(line, pbf) {
 function writeMultiLine(lines, pbf, closed) {
     var len = lines.length,
         i;
-    if (len !== 1) {
-        var lengths = [];
-        for (i = 0; i < len; i++) lengths.push(lines[i].length - (closed ? 1 : 0));
-        pbf.writePackedVarint(2, lengths);
-        // TODO faster with custom writeMessage?
+    var lengths = [];
+    for (i = 0; i < len; i++) {
+        lengths.push(lines[i].length - (closed ? 1 : 0));
     }
+    pbf.writePackedVarint(2, lengths);
+
     var coords = [];
     for (i = 0; i < len; i++) populateLine(coords, lines[i], closed);
     pbf.writePackedSVarint(3, coords);
@@ -186,14 +186,12 @@ function writeMultiLine(lines, pbf, closed) {
 function writeMultiPolygon(polygons, pbf) {
     var len = polygons.length,
         i, j;
-    if (len !== 1 || polygons[0].length !== 1) {
-        var lengths = [len];
-        for (i = 0; i < len; i++) {
-            lengths.push(polygons[i].length);
-            for (j = 0; j < polygons[i].length; j++) lengths.push(polygons[i][j].length - 1);
-        }
-        pbf.writePackedVarint(2, lengths);
+    var lengths = [len];
+    for (i = 0; i < len; i++) {
+        lengths.push(polygons[i].length);
+        for (j = 0; j < polygons[i].length; j++) lengths.push(polygons[i][j].length - 1);
     }
+    pbf.writePackedVarint(2, lengths);
 
     var coords = [];
     for (i = 0; i < len; i++) {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "bin": {
     "geobuf2json": "bin/geobuf2json",
     "json2geobuf": "bin/json2geobuf",
-    "shp2geobuf": "bin/shp2geobuf"
+    "shp2geobuf": "bin/shp2geobuf",
+    "json2geobufb64": "bin/json2geobufb64"
   },
   "scripts": {
     "pretest": "eslint *.js test/*.js",


### PR DESCRIPTION
I use [go-geobuf](https://github.com/cairnapp/go-geobuf) and compared to that implementation, the mapbox implementation seems to ignore writing certain data when the number of rings are low. I add this back to the implementation to make it consistent to the golang implementation